### PR TITLE
Fix naming issue for salinity

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,12 +18,12 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/linux_nightly.yml
+++ b/.github/workflows/linux_nightly.yml
@@ -18,12 +18,12 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -18,12 +18,12 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/mac_nightly.yml
+++ b/.github/workflows/mac_nightly.yml
@@ -18,12 +18,12 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,12 +18,12 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/windows_nightly.yml
+++ b/.github/workflows/windows_nightly.yml
@@ -18,12 +18,12 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WorldOceanAtlasTools"
 uuid = "04f20302-f1b9-11e8-29d9-7d841cb0a64a"
 authors = ["Benoit Pasquier <briochemc@gmail.com>"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/src/names.jl
+++ b/src/names.jl
@@ -233,8 +233,8 @@ WOA_decade(tracer) = @match my_varname(tracer) begin
     _ => error(incorrect_varname(tracer))
 end
 
-WOA_v2(tracer) = @match my_varname(tracer) begin
-    "Salt" => "v2"
+WOA_v2(tracer; product_year=2018) = @match my_varname(tracer) begin
+    "Salt" => my_product_year(product_year) == "13" ? "v2" : ""
     "Dens" || "Temp" || "Cond" || "O2" || "O2sat" || "AOU" || "DSi" || "DIP" || "DIN" => ""
     _ => error(incorrect_varname(tracer))
 end
@@ -249,7 +249,7 @@ function WOA_NetCDF_filename(tracer; product_year=2018, period=0, resolution=1)
                   WOA_filename_varname(tracer),
                   WOA_averaging_period(period), "_",
                   WOA_filename_resolution(resolution),
-                  WOA_v2(tracer), ".nc")
+                  WOA_v2(tracer; product_year), ".nc")
 end
 
 #============================================================

--- a/test/test_functions.jl
+++ b/test/test_functions.jl
@@ -1,5 +1,16 @@
 
 
+@testset "NetCDF filename v2 suffix" begin
+    # WOA13 salinity files have a "v2" suffix
+    @test WOA.WOA_NetCDF_filename("s"; product_year=2013, period=0, resolution=1) == "woa13_decav_s00_01v2.nc"
+    # WOA18 and WOA23 salinity files do not
+    @test WOA.WOA_NetCDF_filename("s"; product_year=2018, period=0, resolution=1) == "woa18_decav_s00_01.nc"
+    @test WOA.WOA_NetCDF_filename("s"; product_year=2023, period=0, resolution=1) == "woa23_decav_s00_01.nc"
+    # Temperature never has the v2 suffix
+    @test WOA.WOA_NetCDF_filename("t"; product_year=2013, period=0, resolution=1) == "woa13_decav_t00_01.nc"
+    @test WOA.WOA_NetCDF_filename("t"; product_year=2023, period=0, resolution=1) == "woa23_decav_t00_01.nc"
+end
+
 @testset "Testing functions" begin
     product_year = 2023
     tracer = "p"


### PR DESCRIPTION
apparently the "v2" needs to be added only for the product from year 2013. The other products do not have the "v2" suffix